### PR TITLE
drag&drop操作時にDropZoneに色を付けて強調できるオプションを追加

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -16,7 +16,10 @@ const initialize = {
     drop: false,
     dropText: 'image drop here !!'
 };
-const ReactImageBase64 = (props = Object.assign({}, initialize)) => {
+const ReactImageBase64 = (props) => {
+    // 初期値を設定
+    console.log(props);
+    props = Object.assign(Object.assign({}, initialize), props);
     // ファイル選択時のハンドラー
     const handleFileChange = (e) => {
         // 入力チェック

--- a/dist/index.js
+++ b/dist/index.js
@@ -16,9 +16,7 @@ const initialize = {
     drop: false,
     dropText: 'image drop here !!'
 };
-const ReactImageBase64 = (props) => {
-    // 初期値を設定
-    props = Object.assign(Object.assign({}, initialize), props);
+const ReactImageBase64 = (props = Object.assign({}, initialize)) => {
     // ファイル選択時のハンドラー
     const handleFileChange = (e) => {
         // 入力チェック

--- a/dist/index.js
+++ b/dist/index.js
@@ -10,6 +10,8 @@ const initialize = {
     accept: "image/*",
     capture: undefined,
     multiple: false,
+    highlight: false,
+    highlight_color: "#e1e7ff",
     handleChange: () => { },
     maxFileSize: 10485760,
     thumbnail_size: 500,
@@ -17,8 +19,9 @@ const initialize = {
     dropText: 'image drop here !!'
 };
 const ReactImageBase64 = (props) => {
+    // Drag&Drop操作の状態を管理
+    const [isHover, setIsHover] = react_1.default.useState(false);
     // 初期値を設定
-    console.log(props);
     props = Object.assign(Object.assign({}, initialize), props);
     // ファイル選択時のハンドラー
     const handleFileChange = (e) => {
@@ -147,10 +150,12 @@ const ReactImageBase64 = (props) => {
     const handleDragEnter = (e) => {
         e.preventDefault();
         e.stopPropagation();
+        setIsHover(true);
     };
     const handleDragLeave = (e) => {
         e.preventDefault();
         e.stopPropagation();
+        setIsHover(false);
     };
     const handleDragOver = (e) => {
         e.preventDefault();
@@ -159,13 +164,19 @@ const ReactImageBase64 = (props) => {
     const handleDrop = (e) => {
         e.preventDefault();
         e.stopPropagation();
+        setIsHover(false);
         var files = e.dataTransfer.files;
         if (files.length === 0) {
             return;
         }
         handleFileChange({ target: { files } });
     };
-    const DropZone = ({ children, dropText }) => (react_1.default.createElement("div", { id: "drop-zone", onDrop: e => handleDrop(e), onDragOver: e => handleDragOver(e), onDragEnter: e => handleDragEnter(e), onDragLeave: e => handleDragLeave(e) },
+    const DropZone = ({ children, dropText }) => (react_1.default.createElement("div", { id: "drop-zone", style: props.highlight && isHover ? {
+            background: props.highlight_color,
+            backgroundImage: 'repeating-linear-gradient(-45deg, #fff, #fff 7px, transparent 0, transparent 14px)'
+        } : {
+            background: 'none'
+        }, onDrop: e => handleDrop(e), onDragOver: e => handleDragOver(e), onDragEnter: e => handleDragEnter(e), onDragLeave: e => handleDragLeave(e) },
         react_1.default.createElement("p", null, dropText),
         children));
     return ((() => {

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -32,6 +32,8 @@ const App = () => {
                 thumbnail_size={100}
                 drop={true}
                 dropText="ファイルをドラッグ＆ドロップもしくは"
+                highlight={true}
+                highlight_color="#6666ff"
                 capture="environment"
                 multiple={true}
                 handleChange={data => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image-base64",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "画像ファイルをBase64に変換するReact用コンポーネントです",
   "scripts": {
     "build": "tsc",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,8 @@ type Props = {
   accept?: string,
   capture?: string,
   multiple?: boolean,
+  highlight?: boolean,
+  highlight_color?: string,
   handleChange: (arg0: Return) => void; 
   maxFileSize: number;
   thumbnail_size: number;
@@ -18,6 +20,8 @@ const initialize = {
   accept: "image/*",
   capture: undefined,
   multiple: false,
+  highlight: false,
+  highlight_color: "#e1e7ff",
   handleChange: () => {},
   maxFileSize: 10485760, // アップロード可能な最大ファイルサイズ 10BM
   thumbnail_size: 500, // 画像リサイズ後の縦横の最大値
@@ -37,6 +41,8 @@ type Return = {
 }
 
 const ReactImageBase64: FC<Props> = (props) => {
+  // Drag&Drop操作の状態を管理
+  const [isHover, setIsHover] = React.useState(false);
 
   // 初期値を設定
   props = {...initialize, ...props}
@@ -194,10 +200,12 @@ const ReactImageBase64: FC<Props> = (props) => {
   const handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
+    setIsHover(true);
   };
   const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
+    setIsHover(false);
   };
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -206,6 +214,7 @@ const ReactImageBase64: FC<Props> = (props) => {
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
+    setIsHover(false);
     var files = e.dataTransfer.files;
     if (files.length === 0) {
       return;
@@ -215,6 +224,12 @@ const ReactImageBase64: FC<Props> = (props) => {
 
   const DropZone: FC<{dropText: string}> = ({children, dropText}) => (
     <div id="drop-zone" 
+      style={props.highlight && isHover ? {
+        background: props.highlight_color,
+        backgroundImage: 'repeating-linear-gradient(-45deg, #fff, #fff 7px, transparent 0, transparent 14px)'
+      } : {
+        background: 'none'
+      }}
       onDrop={e => handleDrop(e)}
       onDragOver={e => handleDragOver(e)}
       onDragEnter={e => handleDragEnter(e)}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,12 @@
 import React, { FC } from "react";
 import heic2any from "heic2any";
 
-interface IProps {
+type Props = {
   id?: string,
   accept?: string,
   capture?: string,
   multiple?: boolean,
-  handleChange: (arg0: IReturn) => void; 
+  handleChange: (arg0: Return) => void; 
   maxFileSize: number;
   thumbnail_size: number;
   drop: boolean;
@@ -25,7 +25,7 @@ const initialize = {
   dropText: 'image drop here !!'
 }
 
-interface IReturn {
+type Return = {
   result: boolean,
   messages: string[],
   fileName?: string,
@@ -36,10 +36,7 @@ interface IReturn {
   fileType?: string,
 }
 
-const ReactImageBase64: FC<IProps> = (props) => {
-
-  // 初期値を設定
-  props = {...initialize, ...props}
+const ReactImageBase64: FC<Props> = (props = {...initialize}) => {
 
   // ファイル選択時のハンドラー
   const handleFileChange = (e: { target: { files: any; }; }) => {
@@ -58,7 +55,7 @@ const ReactImageBase64: FC<IProps> = (props) => {
       props.handleChange({ result: false, messages: values })
     }
 
-    const successCallback = (values: IReturn) => {
+    const successCallback = (values: Return) => {
       props.handleChange({ 
         ...values
       })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,7 +36,10 @@ type Return = {
   fileType?: string,
 }
 
-const ReactImageBase64: FC<Props> = (props = {...initialize}) => {
+const ReactImageBase64: FC<Props> = (props) => {
+
+  // 初期値を設定
+  props = {...initialize, ...props}
 
   // ファイル選択時のハンドラー
   const handleFileChange = (e: { target: { files: any; }; }) => {


### PR DESCRIPTION
`<ReactImageBase64/>`に新たな属性`highlight`および`highlight_color`を用意し、
ユーザがファイルを`<DropZone/>`内にドラッグアンドドロップしようとしたときエリアが指定した色でハイライトされる機能を追加した。
なお`highlight`および`highlight_color`は省略可能であり、標準ではこの機能は無効化されている。  

- `highlight`
  - true/false
- `highlight_color`
  - "#12ffab"のようなカラーコードで指定できる

![highlighting](https://user-images.githubusercontent.com/43945424/115994518-4e681c00-a612-11eb-94f2-2185222a6c5c.gif)
